### PR TITLE
Fix unsafe char handling in text utilities

### DIFF
--- a/src/book/ctg/ctg.cpp
+++ b/src/book/ctg/ctg.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <sstream>
 #include <iomanip>
+#include <cctype>
 #include "../../position.h"
 #include "../../uci.h"
 #include "ctg.h"
@@ -476,10 +477,10 @@ void CtgBook::invert_board(CtgPositionData& positionData) const {
             if (p == ' ')
                 continue;
 
-            if (p == toupper(p))
-                p = tolower(p);
+            if (p == toupper(static_cast<unsigned char>(p)))
+                p = char(tolower(static_cast<unsigned char>(p)));
             else
-                p = toupper(p);
+                p = char(toupper(static_cast<unsigned char>(p)));
         }
     }
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "misc.h"
+#include <cctype>
 
 #ifdef _WIN32
     #if _WIN32_WINNT < 0x0601
@@ -803,7 +804,10 @@ CommandLine::CommandLine(int _argc, char** _argv) :
 
     static std::string Empty = EMPTY;
     return std::equal(fn.begin(), fn.end(), Empty.begin(), Empty.end(),
-                      [](char a, char b) { return tolower(a) == tolower(b); });
+                      [](char a, char b) {
+                          return std::tolower(static_cast<unsigned char>(a))
+                               == std::tolower(static_cast<unsigned char>(b));
+                      });
 }
 
 /*static*/ std::string Util::fix_path(const std::string& p) {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1015,10 +1015,11 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
     while ((ss >> token) && !isspace(token))
     {
         Square rsq;
-        Color  c    = islower(token) ? BLACK : WHITE;
+        unsigned char uc = static_cast<unsigned char>(token);
+        Color  c    = std::islower(uc) ? BLACK : WHITE;
         Piece  rook = make_piece(c, ROOK);
 
-        token = char(toupper(token));
+        token = char(std::toupper(uc));
 
         if (token == 'K')
             for (rsq = relative_square(c, SQ_H1); piece_on(rsq) != rook; --rsq)
@@ -2004,7 +2005,10 @@ void Position::flip() {
     f += token + " ";
 
     std::transform(f.begin(), f.end(), f.begin(),
-                   [](char c) { return char(islower(c) ? toupper(c) : tolower(c)); });
+                   [](char c) {
+                       unsigned char uc = static_cast<unsigned char>(c);
+                       return char(std::islower(uc) ? std::toupper(uc) : std::tolower(uc));
+                   });
 
     ss >> token;  // En passant square
     f += (token == "-" ? token : token.replace(1, 1, token[1] == '3' ? "6" : "3"));

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -528,7 +528,7 @@ std::string UCI::wdl(Value v, int ply) {
 
 Move UCI::to_move(const Position& pos, std::string& str) {
     if (str.length() == 5)
-        str[4] = char(tolower(str[4]));  // The promotion piece character must be lowercased
+        str[4] = char(tolower(static_cast<unsigned char>(str[4])));  // The promotion piece character must be lowercased
 
     for (const auto& m : MoveList<LEGAL>(pos))
         if (str == move(m, pos.is_chess960()))

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -33,7 +33,10 @@ bool CaseInsensitiveLess::operator()(const std::string& s1, const std::string& s
 
     return std::lexicographical_compare(
       s1.begin(), s1.end(), s2.begin(), s2.end(),
-      [](char c1, char c2) { return std::tolower(c1) < std::tolower(c2); });
+      [](char c1, char c2) {
+          return std::tolower(static_cast<unsigned char>(c1))
+               < std::tolower(static_cast<unsigned char>(c2));
+      });
 }
 
 void OptionsMap::setoption(std::istringstream& is) {


### PR DESCRIPTION
## Summary
- avoid UB in character conversions by casting to unsigned char before tolower/toupper
- include `<cctype>` for tolower/toupper declarations

## Testing
- `g++ -std=c++17 -c src/book/ctg/ctg.cpp -I src`
- `g++ -std=c++17 -c src/misc.cpp -I src`
- `g++ -std=c++17 -c src/position.cpp -I src`
- `g++ -std=c++17 -c src/uci.cpp -I src`
- `g++ -std=c++17 -c src/ucioption.cpp -I src`

------
https://chatgpt.com/codex/tasks/task_e_684384470b58832aa9be7a2bb552cdbf