### PR TITLE
Add attack bonus evaluation feature

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -209,6 +209,10 @@ Engine::Engine(std::optional<std::string> path) :
                                      Search::set_variety(o);
                                      return std::optional<std::string>{};
                                  });  //variety
+    options["Attack Bonus"] << Option(0, 0, 100, [](const Option& o) {
+        Eval::set_attack_bonus_strength(int(o));
+        return std::nullopt;
+    });
     options["Concurrent Experience"]
       << Option(false);  //for a same experience file on a same folder
     load_networks();

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -49,6 +49,7 @@ Value evaluate(const NNUE::Networks&          networks,
                const Position&                pos,
                Eval::NNUE::AccumulatorCaches& caches,
                int                            optimism);
+void  set_attack_bonus_strength(int bonus);
 }  // namespace Eval
 
 }  // namespace Brainlearn


### PR DESCRIPTION
## Summary
- add a simple attack bonus evaluation heuristic
- expose strength control via new `Attack Bonus` UCI option

## Testing
- `bash Tests/perft.sh` *(fails: `expect` not found)*
- `python3 Tests/instrumented.py` *(fails: `ModuleNotFoundError: No module named 'requests'`)*

------
https://chatgpt.com/codex/tasks/task_e_684e966145b8832a80edd4bf02ffd79a